### PR TITLE
fix skip_download option when extracting metadata

### DIFF
--- a/tiktokslideshow-download.py
+++ b/tiktokslideshow-download.py
@@ -238,7 +238,7 @@ def check_audio_only(url, cookies_file):
         "noplaylist": True,  # Single video download
         "quiet": False,  # Verbose output
         "cookiefile": netscape_cookies,  # Use cookies
-        "nodownload":True, # Don't download the video
+        "skip_download":True, # Don't download the video
     }
 
     try:


### PR DESCRIPTION
No idea how it was missed when I was running the original tests, but it looks like the parameter to skip downloading is different than i remembered it being when i was writing bash url extractor based on the same thing.

Changes:

- fixes audio checks so it **doesn't** download the video/mp3 file every time