### PR TITLE
ci: add workflow to auto-merge Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,17 @@
+name: "Enable auto-merge for Dependabot PRs"
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  enable-auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge
+        uses: peter-evans/enable-pull-request-automerge@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          pull-request-number: ${{ github.event.pull_request.number }}
+          merge-method: squash


### PR DESCRIPTION
Introduce a new GitHub Actions workflow that enables auto-merge for
pull requests created by dependabot[bot]. The workflow listens for
`pull_request` events (opened, synchronized, reopened) and applies
auto-merge using squash as the merge method.
